### PR TITLE
arguments for otp_code_verification.dart navigation page

### DIFF
--- a/lib/common/navigation/coco_navigation.dart
+++ b/lib/common/navigation/coco_navigation.dart
@@ -12,6 +12,7 @@ class CocoNavigation {
     GetPage(
       name: CocoRoutes.keyOTPVerificationCode,
       page: () => const OTPCodeVerification(),
+      arguments: String,
     ),
   ];
 }


### PR DESCRIPTION
The argument is the number we want to authenticate against the OTP code